### PR TITLE
add dryRun param, use scopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 project/
+target/
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -10,5 +10,6 @@ libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.2",
   "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
+  "com.github.scopt" %% "scopt" % "4.0.0-RC2",
   "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 )

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -6,11 +6,11 @@ import services.{CredentialsProvider, S3, Ssm}
 object Main extends App {
 
   Options.parse(args) match {
-    case Some(Options(dryRun, Some(S3Mode), profile, Some(bucket), path, prefix)) =>
-      put(fromS3(profile, bucket, path, prefix), profile, dryRun)
+    case Some(Options(dryRun, overwrite, Some(S3Mode), profile, Some(bucket), path, prefix)) =>
+      put(fromS3(profile, bucket, path, prefix), profile, dryRun, overwrite)
 
-    case Some(Options(dryRun, Some(LocalMode), profile, _, path, prefix)) =>
-      put(fromLocal(path, prefix), profile, dryRun)
+    case Some(Options(dryRun, overwrite, Some(LocalMode), profile, _, path, prefix)) =>
+      put(fromLocal(path, prefix), profile, dryRun, overwrite)
 
     case _ => println(Options.usage)
   }
@@ -30,11 +30,11 @@ object Main extends App {
     Parameters.fromConfig(config, Some(prefix))
   }
 
-  def put(parameters: Map[String,String], profile: String, dryRun: Boolean) = {
-    println(s"\nMigrating (dryRun = $dryRun):\n${pretty(parameters)}")
+  def put(parameters: Map[String,String], profile: String, dryRun: Boolean, overwrite: Boolean) = {
+    println(s"\nMigrating (dryRun = $dryRun, overwrite = $overwrite):\n${pretty(parameters)}")
 
     if (!dryRun) {
-      val ssm = new Ssm(CredentialsProvider(profile))
+      val ssm = new Ssm(CredentialsProvider(profile), overwrite)
       parameters foreach (ssm.put _).tupled
     }
   }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,27 +4,15 @@ import com.typesafe.config._
 import services.{CredentialsProvider, S3, Ssm}
 
 object Main extends App {
-  def info = Console.err.println(
-    """
-      |====
-      |Migrates a Typesafe (HOCON) config file to AWS Parameter Store.
-      |
-      |To migrate a file from S3:
-      |  sbt "run s3 <profile> <bucket> <path> <prefix>"
-      |
-      |Or to migrate a local file:
-      |  sbt "run local <profile> <path> <prefix>"
-      |
-      |E.g. `run s3 my-aws-account my-config-bucket path/to/file.conf /AppName/Stage/`
-    """.stripMargin
-  )
 
-  args.toList match {
-    case "s3" :: profile :: bucket :: path :: prefix :: Nil => put(fromS3(profile, bucket, path, prefix), profile)
+  Options.parse(args) match {
+    case Some(Options(dryRun, Some(S3Mode), profile, Some(bucket), path, prefix)) =>
+      put(fromS3(profile, bucket, path, prefix), profile, dryRun)
 
-    case "local" :: profile :: path :: prefix :: Nil => put(fromLocal(path, prefix), profile)
+    case Some(Options(dryRun, Some(LocalMode), profile, _, path, prefix)) =>
+      put(fromLocal(path, prefix), profile, dryRun)
 
-    case _ => info
+    case _ => println(Options.usage)
   }
 
   def fromS3(profile: String, bucket: String, path: String, prefix: String): Map[String,String] = {
@@ -42,11 +30,13 @@ object Main extends App {
     Parameters.fromConfig(config, Some(prefix))
   }
 
-  def put(parameters: Map[String,String], profile: String) = {
-    println(s"\nMigrating:\n${pretty(parameters)}")
+  def put(parameters: Map[String,String], profile: String, dryRun: Boolean) = {
+    println(s"\nMigrating (dryRun = $dryRun):\n${pretty(parameters)}")
 
-    val ssm = new Ssm(CredentialsProvider(profile))
-    parameters foreach (ssm.put _).tupled
+    if (!dryRun) {
+      val ssm = new Ssm(CredentialsProvider(profile))
+      parameters foreach (ssm.put _).tupled
+    }
   }
 
   def pretty(parameters: Map[String,String]): String =

--- a/src/main/scala/Options.scala
+++ b/src/main/scala/Options.scala
@@ -6,6 +6,7 @@ case object LocalMode extends Mode
 
 case class Options(
   dryRun: Boolean = false,
+  overwrite: Boolean = false,
   mode: Option[Mode] = None,
   profile: String = "",
   bucket: Option[String] = None,
@@ -33,8 +34,12 @@ object Options {
         .children(
           opt[Unit]('d', "dryRun")
             .optional
-            .action((d, o) => o.copy(dryRun = true))
+            .action((_, o) => o.copy(dryRun = true))
             .text("Prints the parameters that will be created but does not write to Parameter Store"),
+          opt[Unit]('o', "overwrite")
+            .optional
+            .action((_, o) => o.copy(overwrite = true))
+            .text("Overwrites existing items in Parameter Store"),
           arg[String]("<profile>")
             .required
             .action((p, o) => o.copy(profile = p))
@@ -59,8 +64,12 @@ object Options {
         .children(
           opt[Unit]('d', "dryRun")
             .optional
-            .action((d, o) => o.copy(dryRun = true))
+            .action((_, o) => o.copy(dryRun = true))
             .text("Prints the parameters that will be created but does not write to Parameter Store"),
+          opt[Unit]('o', "overwrite")
+            .optional
+            .action((_, o) => o.copy(overwrite = true))
+            .text("Overwrites existing items in Parameter Store"),
           arg[String]("<profile>")
             .required
             .action((p, o) => o.copy(profile = p))

--- a/src/main/scala/Options.scala
+++ b/src/main/scala/Options.scala
@@ -1,0 +1,79 @@
+import scopt.OParser
+
+sealed trait Mode
+case object S3Mode extends Mode
+case object LocalMode extends Mode
+
+case class Options(
+  dryRun: Boolean = false,
+  mode: Option[Mode] = None,
+  profile: String = "",
+  bucket: Option[String] = None,
+  path: String = "",
+  prefix: String = ""
+)
+
+object Options {
+
+  def parse(args: Array[String]): Option[Options] =
+    OParser.parse(optionsParser, args, Options())
+
+  def usage = OParser.usage(optionsParser)
+
+  private val builder = OParser.builder[Options]
+
+  private val optionsParser = {
+    import builder._
+
+    OParser.sequence(
+      programName("parameter-store-migration"),
+      cmd("s3")
+        .action((_, o) => o.copy(mode = Some(S3Mode)))
+        .text("Migrate a file from S3")
+        .children(
+          opt[Unit]('d', "dryRun")
+            .optional
+            .action((d, o) => o.copy(dryRun = true))
+            .text("Prints the parameters that will be created but does not write to Parameter Store"),
+          arg[String]("<profile>")
+            .required
+            .action((p, o) => o.copy(profile = p))
+            .text("AWS profile name"),
+          arg[String]("<bucket>")
+            .required
+            .action((b, o) => o.copy(bucket = Some(b)))
+            .text("S3 bucket name"),
+          arg[String]("<path>")
+            .required
+            .action((p, o) => o.copy(path = p))
+            .text("Path of the file to migrate"),
+          arg[String]("<prefix>")
+            .required
+            .action((p, o) => o.copy(prefix = p))
+            .text("A prefix for the Parameter Store key names")
+        ),
+
+      cmd("local")
+        .action((_, o) => o.copy(mode = Some(LocalMode)))
+        .text("Migrate a local file")
+        .children(
+          opt[Unit]('d', "dryRun")
+            .optional
+            .action((d, o) => o.copy(dryRun = true))
+            .text("Prints the parameters that will be created but does not write to Parameter Store"),
+          arg[String]("<profile>")
+            .required
+            .action((p, o) => o.copy(profile = p))
+            .text("AWS profile name"),
+          arg[String]("<path>")
+            .required
+            .action((p, o) => o.copy(path = p))
+            .text("Path of the file to migrate"),
+          arg[String]("<prefix>")
+            .required
+            .action((p, o) => o.copy(prefix = p))
+            .text("A prefix for the Parameter Store key names"),
+        )
+    )
+  }
+}

--- a/src/main/scala/Parameters.scala
+++ b/src/main/scala/Parameters.scala
@@ -23,7 +23,11 @@ object Parameters {
 
         listItemValue.valueType match {
           case ConfigValueType.STRING | ConfigValueType.NUMBER | ConfigValueType.BOOLEAN =>
-            params + (s"$key.$index" -> listItemValue.unwrapped.toString)
+            if (listItemValue.unwrapped.toString.isEmpty) {
+              println(s"Ignoring empty string value in list for key $key")
+              params
+            }
+            else params + (s"$key.$index" -> listItemValue.unwrapped.toString)
 
           case ConfigValueType.OBJECT =>
             params ++ fromConfig(
@@ -55,7 +59,11 @@ object Parameters {
 
       entry.getValue.valueType match {
         case ConfigValueType.STRING | ConfigValueType.NUMBER | ConfigValueType.BOOLEAN =>
-          params + (key -> entry.getValue.unwrapped.toString)
+          if (entry.getValue.unwrapped.toString.isEmpty) {
+            println(s"Ignoring empty string value for key $key")
+            params
+          }
+          else params + (key -> entry.getValue.unwrapped.toString)
 
         case ConfigValueType.LIST =>
           params ++ fromList(key, config)

--- a/src/main/scala/services/Ssm.scala
+++ b/src/main/scala/services/Ssm.scala
@@ -5,7 +5,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.simplesystemsmanagement.model.{ParameterType, PutParameterRequest}
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
 
-class Ssm(credentialsProvider: AWSCredentialsProviderChain) {
+class Ssm(credentialsProvider: AWSCredentialsProviderChain, overwrite: Boolean) {
   private val ssmClient: AWSSimpleSystemsManagement =
     AWSSimpleSystemsManagementClientBuilder
       .standard()
@@ -18,6 +18,7 @@ class Ssm(credentialsProvider: AWSCredentialsProviderChain) {
         .withName(key)
         .withValue(value)
         .withType(ParameterType.SecureString)
+        .withOverwrite(overwrite)
 
     ssmClient.putParameter(request)
   }


### PR DESCRIPTION
Adding `-d` or `--dryRun` causes the program to print the parameters without actually sending them to PS.
Adding `-o` or `--overwrite` makes it overwrite any existing entries in Parameter Store.

I've also switched to using [scopt](https://github.com/scopt/scopt) for command line parsing